### PR TITLE
Rate-limit 'wheel' events

### DIFF
--- a/application/clientgui.js
+++ b/application/clientgui.js
@@ -593,13 +593,17 @@ wdi.ClientGui = $.spcExtend(wdi.EventObject.prototype, {
 
 		var mouseEventPause = false;
 
-		eventLayer.bind('mousewheel', function(event, delta) {
+		var fireWheel = _.throttle(function(event, delta) {
 			var button = delta > 0 ? 3 : 4;
 
 			self.generateEvent.call(self, 'mousedown', button);
 			self.generateEvent.call(self, 'mouseup', button);
 
 			return false;
+		}, 60);
+
+		eventLayer.bind('mousewheel', function(event, delta) {
+			fireWheel(event, delta);
 		});
 
 		this.fire('eventLayerCreated', eventLayer[0]);

--- a/application/clientgui.js
+++ b/application/clientgui.js
@@ -602,9 +602,7 @@ wdi.ClientGui = $.spcExtend(wdi.EventObject.prototype, {
 			return false;
 		}, 60);
 
-		eventLayer.bind('mousewheel', function(event, delta) {
-			fireWheel(event, delta);
-		});
+		eventLayer.bind('mousewheel', fireWheel);
 
 		this.fire('eventLayerCreated', eventLayer[0]);
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "spice-web-client",
-  "version": "1.4.251",
+  "version": "1.4.252",
   "authors": [
     "eyeos"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "spice-web-client",
-  "version": "1.4.250",
+  "version": "1.4.251",
   "authors": [
     "eyeos"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spice-web-client",
-  "version": "1.4.241",
+  "version": "1.4.242",
   "description": "SPICE client root module",
   "author": "eyeos",
   "homepage": "http://www.eyeos.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spice-web-client",
-  "version": "1.4.240",
+  "version": "1.4.241",
   "description": "SPICE client root module",
   "author": "eyeos",
   "homepage": "http://www.eyeos.com",


### PR DESCRIPTION
When smooth scrolling is enabled (touch screens, high-end touchpads),
the browser emits a lot of wheel events with very small deltas.

We aren't sending those deltas to the server, so we ended up scrolling
way too fast on those cases.

This commit limits the amount of 'wheel' events sent to the server.
