### PR TITLE
Allow index.html to take vmhost as a query string parameter

### DIFF
--- a/run.js
+++ b/run.js
@@ -230,7 +230,7 @@ function start () {
 		'port': 8000,
 		'protocol': 'ws',
 		'token': 'password',
-		'vmHost': 'localhost',
+		'vmHost': getURLParameter('vmhost') || 'localhost',
 		'vmPort': getURLParameter('vmport') || 5900,
 		'useBus': false,
 		'busHost': 'localhost',


### PR DESCRIPTION
This is useful for testing on Mac OS X, for example where the docker container running the SPICE server is running in a virtual machine, so is not running on localhost, but on some other IP.
